### PR TITLE
Fix GIF sticker

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,6 @@ $ cd whatsapp-bot
 4. Install all the required dependencies by running, and get the bot online
 ```sh
 $ npm i
-$ npm i ffmpeg -g
-$ npm i gify-cli -g
 $ node .
 ```
 5. It will gives you a QR code which you can scan using your WhatsApp Web account

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ $ cd whatsapp-bot
 4. Install all the required dependencies by running, and get the bot online
 ```sh
 $ npm i
+$ npm i ffmpeg -g
+$ npm i gify-cli -g
 $ node .
 ```
 5. It will gives you a QR code which you can scan using your WhatsApp Web account

--- a/commands/sticker.js
+++ b/commands/sticker.js
@@ -6,6 +6,7 @@ const fs = require("fs");
 const uaOverride = "WhatsApp/2.2029.4 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36";
 
 exports.run = async (bot, message) => {
+
     if (message.isMediaObj && message.type === "image") {
         const waiting = await bot.sendText(message.from, "_⌛ Please wait..._");
         const media = await decryptMedia(message.isMediaObj, uaOverride);
@@ -25,10 +26,10 @@ exports.run = async (bot, message) => {
         bot.reply(message.from, "_⌛ Please wait..._", message.id);
         const mediaData = await decryptMedia(message, uaOverride);
         const filename = `./assets/stickers/sticker.mp4`;
-
+        
         fs.writeFileSync(filename, mediaData);
         try {
-            exec(`gify ./assets/stickers/sticker.mp4 ./assets/stickers/output.gif --fps=30 --scale=240:240`, async (error, stdout, stderr) => {
+            exec(`gify ./assets/stickers/sticker.mp4 ./assets/stickers/output.gif --fps=60 --scale=240:-1`, async (error, stdout, stderr) => {
                 const gif = fs.readFileSync("./assets/stickers/output.gif", { encoding: "base64" });
                 bot.sendImageAsSticker(message.from, `data:image/gif;base64, ${gif.toString("base64")}`, {
                     author: message.sender.pushname,

--- a/commands/sticker.js
+++ b/commands/sticker.js
@@ -6,7 +6,6 @@ const fs = require("fs");
 const uaOverride = "WhatsApp/2.2029.4 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 Safari/537.36";
 
 exports.run = async (bot, message) => {
-
     if (message.isMediaObj && message.type === "image") {
         const waiting = await bot.sendText(message.from, "_⌛ Please wait..._");
         const media = await decryptMedia(message.isMediaObj, uaOverride);
@@ -26,7 +25,7 @@ exports.run = async (bot, message) => {
         bot.reply(message.from, "_⌛ Please wait..._", message.id);
         const mediaData = await decryptMedia(message, uaOverride);
         const filename = `./assets/stickers/sticker.mp4`;
-        
+
         fs.writeFileSync(filename, mediaData);
         try {
             exec(`gify ./assets/stickers/sticker.mp4 ./assets/stickers/output.gif --fps=60 --scale=240:-1`, async (error, stdout, stderr) => {


### PR DESCRIPTION
-Update wa-automate to 3.2.6

-Add start script

-Update chromiumArgs (no puppeteer args)

-Add ForceRefocus (to prevent bot stops when open WhatsApp web)

-Reply when doesn't send an image (sticker command)