### PR TITLE
feat: Added support for rest latency in ping command

### DIFF
--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,7 +1,7 @@
 const { prefix } = require("../config.json");
 
 exports.run = (bot, message) => {
-    bot.sendText(message.from, "🏓 PONG!");
+    bot.sendText(message.from, `REST Latency: ${Date.now - message.restTimestamp}`);
 };
 
 exports.help = {

--- a/commands/ping.js
+++ b/commands/ping.js
@@ -1,7 +1,7 @@
 const { prefix } = require("../config.json");
 
 exports.run = (bot, message) => {
-    bot.sendText(message.from, `REST Latency: ${Date.now - message.restTimestamp}`);
+    bot.sendText(message.from, `REST Latency: ${Date.now() - message.restTimestamp}ms`);
 };
 
 exports.help = {

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function start(bot) {
     });
 
     bot.onMessage(async message => {
-        message.latencyTimestamp = Date.now();
+        message.restTimestamp = Date.now();
         
         try {
             if (message.body.startsWith(prefix)) {

--- a/index.js
+++ b/index.js
@@ -28,6 +28,8 @@ function start(bot) {
     });
 
     bot.onMessage(async message => {
+        message.latencyTimestamp = Date.now();
+        
         try {
             if (message.body.startsWith(prefix)) {
                 args = message.body.slice(prefix.length).trim().split(/ +/g);


### PR DESCRIPTION
Hey there, I have added support for REST Latency, so users will be able to check how much time in `ms` will take the bot to respond.